### PR TITLE
Update split.yaml

### DIFF
--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -54,6 +54,16 @@ jobs:
           latest: true
           out-file-path: "tmp"
           fileName: '*.ttf'
+
+      - name: Check inputs Tag
+        run: |
+          if [ "${{ github.event.inputs.tag }}" != "null" ]; then
+            echo "tag_name=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
+          else
+            echo "tag_name=${{ steps.down1.outputs.tag_name }}" >> "$GITHUB_ENV"
+          fi
+
+          echo "tag_name is $tag_name"
           
       - name: Show files
         run: |
@@ -63,23 +73,18 @@ jobs:
       - name: Split fonts
         run: |
           npm install @konghayao/cn-font-split -g
+          
           for i in $(echo "$(ls ./tmp)" | grep -i '\.ttf$')
           do
             font_name=$(echo "$i" | sed -E 's/(.+)\.ttf$/\1/i' | tr '[:upper:]' '[:lower:]')
             cn-font-split -i=./tmp/$i -o=./fonts/$font_name --renameOutputFont='[index][ext]'
-            echo "@import url('./$font_name/result.css');" >> ./style.css
+            echo "@import url('./$font_name/result.css');" >> ./$font_name-style.css
+            mv $font_name-style.css fonts/$font_name-style.css
           done
 
-          if [ "${{ github.event.inputs.tag }}" != "null" ]; then
-            echo "${{ github.event.inputs.tag }}" >> VERSION
-          else
-            echo "${{ steps.down1.outputs.tag_name }}" >> VERSION
-          fi
+          echo "$tag_name" >> VERSION
 
-      - name: mv files
-        run: |
           mv VERSION fonts/VERSION
-          mv style.css fonts/style.css
           rm -rf ./tmp/
           ls -a
 
@@ -96,13 +101,8 @@ jobs:
           git checkout -b latest
           git status
           git add .
-          if [ "${{ github.event.inputs.tag }}" != "null" ]; then
-            git commit -m "update ${{ github.event.inputs.tag }}" -a
-            git tag ${{ github.event.inputs.tag }}
-          else
-            git commit -m "update ${{ steps.down1.outputs.tag_name }}" -a
-            git tag ${{ steps.down1.outputs.tag_name }}
-          fi
+          git commit -m "update $tag_name" -a
+          git tag $tag_name
 
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0

--- a/.github/workflows/split.yaml
+++ b/.github/workflows/split.yaml
@@ -2,6 +2,10 @@ name: Split Fonts
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release Tag, e.g. normal is v1.330, patach version v1.330.1'
+        required: false
 
 jobs:
   build:
@@ -11,37 +15,76 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4.0.1
+      - uses: actions/setup-node@v4
         with: 
-          node-version: '>=18.0.0'
+          node-version: '20'
 
-      - name: Download fonts
-        id: down
-        uses: robinraju/release-downloader@v1.8
+      - name: Download LxgwWenKai
+        id: down1
+        uses: robinraju/release-downloader@v1.10
         with:
           repository: lxgw/LxgwWenKai
           latest: true
           out-file-path: "tmp"
+          fileName: '*.ttf'
+      
+      - name: Download LxgwWenKai-Screen
+        id: down2
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: lxgw/LxgwWenKai-Screen
+          latest: true
+          out-file-path: "tmp"
+          fileName: '*.ttf'
+
+      - name: Download LxgwWenkai-TC
+        id: down3
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: lxgw/LxgwWenkaiTC
+          latest: true
+          out-file-path: "tmp"
+          fileName: '*.ttf'
+
+      - name: Download LxgwWenkai-GB
+        id: down4
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: lxgw/LxgwWenkaiGB
+          latest: true
+          out-file-path: "tmp"
+          fileName: '*.ttf'
+          
+      - name: Show files
+        run: |
+          ls -a
+          ls tmp
 
       - name: Split fonts
         run: |
-          npm install cn-font-split -g
-          rm -rf ./fonts/
-          rm -rf ./style.css
-          rm -rf ./VERSION
+          npm install @konghayao/cn-font-split -g
           for i in $(echo "$(ls ./tmp)" | grep -i '\.ttf$')
-          do 
+          do
             font_name=$(echo "$i" | sed -E 's/(.+)\.ttf$/\1/i' | tr '[:upper:]' '[:lower:]')
             cn-font-split -i=./tmp/$i -o=./fonts/$font_name --renameOutputFont='[index][ext]'
             echo "@import url('./$font_name/result.css');" >> ./style.css
           done
-          echo "${{ steps.down.outputs.tag_name }}" >> VERSION
+
+          if [ "${{ github.event.inputs.tag }}" != "null" ]; then
+            echo "${{ github.event.inputs.tag }}" >> VERSION
+          else
+            echo "${{ steps.down1.outputs.tag_name }}" >> VERSION
+          fi
+
+      - name: mv files
+        run: |
           mv VERSION fonts/VERSION
           mv style.css fonts/style.css
           rm -rf ./tmp/
+          ls -a
 
       - name: Auto Minify
-        uses: nizarmah/auto-minify@v2.1.1
+        uses: nizarmah/auto-minify@v3
 
       - name: Commit files
         run: |
@@ -52,9 +95,14 @@ jobs:
           git config user.name github-actions[bot]
           git checkout -b latest
           git status
-          git add . 
-          git commit -m "update ${{ steps.down.outputs.tag_name }}" -a
-          git tag ${{ steps.down.outputs.tag_name }}
+          git add .
+          if [ "${{ github.event.inputs.tag }}" != "null" ]; then
+            git commit -m "update ${{ github.event.inputs.tag }}" -a
+            git tag ${{ github.event.inputs.tag }}
+          else
+            git commit -m "update ${{ steps.down1.outputs.tag_name }}" -a
+            git tag ${{ steps.down1.outputs.tag_name }}
+          fi
 
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0


### PR DESCRIPTION
1. 增加了手动触发工作流的 可选 tag 标签，好处就是，小修改可以直接制定版本号 1.330 --> 1.330.1，不用删除 tag 再覆盖。
2. node-version: '20'
3. 集齐了四个 LxgwWenKai
4. cn-font-split --> @konghayao/cn-font-split，不然现在会报错，见 https://github.com/KonghaYao/cn-font-split?tab=readme-ov-file#%E5%AE%89%E8%A3%85
5. 后续判断 tag 来源、提交